### PR TITLE
os/bluestore: Alternative

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2248,7 +2248,7 @@ void BlueFS::_wal_update_size(FileRef file) {
 
   FileReader *h = new FileReader(file, cct->_conf->bluefs_max_prefetch, false, true);
 
-  while(flush_offset < file->fnode.allocated) {
+  while (flush_offset < file->fnode.allocated) {
     // read first part of wal flush
     bufferlist bl;
     _read(h, flush_offset, sizeof(File::WALFlush::WALLength), &bl, nullptr);
@@ -2267,6 +2267,7 @@ void BlueFS::_wal_update_size(FileRef file) {
     file->wal_flushes.push_back({flush_offset, flush_length});
     flush_offset += increase;
   }
+  delete h;
 }
 
 int64_t BlueFS::_read_wal(

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2272,7 +2272,7 @@ void BlueFS::_wal_update_size(FileRef file, uint64_t flush_offset, uint64_t incr
   while (flush_offset < file->fnode.wal_limit) {
     // read first part of wal flush
     bufferlist bl;
-    int read_result = _read(h, flush_offset, sizeof(File::WALFlush::WALLength), &bl, nullptr);
+    uint64_t read_result = (uint64_t)_read(h, flush_offset, sizeof(File::WALFlush::WALLength), &bl, nullptr);
     if (read_result < sizeof(File::WALFlush::WALLength)) {
       dout(20) << fmt::format("{} cannot read flush length, most likely we are out of bounds. flush_offset={:#X}", __func__, flush_offset) << dendl;
       break;

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -3628,6 +3628,8 @@ ceph::bufferlist BlueFS::FileWriter::flush_buffer(
   if (partial) {
     tail_block.splice(0, tail_block.length(), &bl);
   }
+  dout(20) << __func__ << " tail is" << std::hex << bl.length() << dendl;
+  ceph_assert(length >= bl.length());
   const auto remaining_len = length - bl.length();
   buffer.splice(0, remaining_len, &bl);
   if (buffer.length()) {

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1521,7 +1521,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
             if (boost::algorithm::ends_with(filename, ".log")) {
               file->is_wal = true;
               file->fnode.size = 0;
-              file->wal_flush_count = 0;
+              _wal_update_size(file);
             }
 
 	    q->second->file_map[filename] = file;

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -235,6 +235,19 @@ public:
   struct File : public RefCountedObject {
     MEMPOOL_CLASS_HELPERS();
 
+    /*
+     * WAL files in bluefs have a different format from normal ones. In order to not flush metadata 
+     * for every write we make to data extents, we create a package/envelope around the real data 
+     * that includes Length of the data we want to flush and a marker that identifies the flush.
+     *
+     * The format on disk will look something like:
+     * legend = l = length of flush, d = data, m = marker, x=unused/used bvy other file, each character will be a byte
+     * 
+     * flush 0 l==24                                                  flush 1 l==4                 flush 2 l==12
+     * v                                                               v                             v
+     * llll llll dddd dddd dddd dddd dddd dddd mmmm mmmm xxxx xxx xxxx llll llll dddd mmmm mmmm xxxx llll llll  dddd dddd dddd mmmm mmmm
+     *
+     */
     struct WALFlush {
       typedef uint64_t WALMarker; 
       typedef uint64_t WALLength; 

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -382,6 +382,11 @@ public:
       std::swap(tail, buffer);
     }
 
+    void remove_trailing(uint64_t amount) {
+      bufferlist bl;
+      bl.substr_of(buffer, 0, buffer.length() - amount);
+    }
+
     uint64_t get_effective_write_pos() {
       return pos + buffer.length();
     }
@@ -623,6 +628,8 @@ private:
 
   int _preallocate(FileRef f, uint64_t off, uint64_t len);
   int _truncate(FileWriter *h, uint64_t off);
+
+  void _wal_update_size(FileRef file);
 
   int64_t _read_wal(
     FileReader *h,   ///< [in] read from here

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -301,8 +301,8 @@ public:
 
     FileRef file;
     uint64_t pos = 0;       ///< start offset for buffer
-  private:
     ceph::buffer::list buffer;      ///< new data to write (at end of file)
+  private:
     ceph::buffer::list tail_block;  ///< existing partial block at end of file, if any
   public:
     unsigned get_buffer_length() const {

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -253,9 +253,14 @@ public:
         return offset + sizeof(WALLength);
       }
 
-      static constexpr uint64_t write_extra_envelope_size() {
-        return sizeof(WALLength)  // prepended first length field
+      static constexpr uint64_t extra_envelope_size_on_front_and_tail() {
+        return sizeof(WALLength) // prepended flush length
           + sizeof(WALMarker) // appended file marker == ino
+          + sizeof(WALLengthZero); // extra 0 overwrite of next WALLength
+      }
+
+      static constexpr uint64_t extra_envelope_size_on_tail() {
+        return sizeof(WALMarker) // appended file marker == ino
           + sizeof(WALLengthZero); // extra 0 overwrite of next WALLength
       }
 
@@ -399,6 +404,10 @@ public:
       uint64_t l0 = get_buffer_length();
       ceph_assert(l0 + sizeof(value) <= std::numeric_limits<unsigned>::max());
       buffer_appender.append((const char*)&value, sizeof(value));
+    }
+
+    void append_hole(uint64_t len) {
+      buffer.append_hole(len);
     }
 
     void prepend(uint64_t value) {

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -242,6 +242,10 @@ public:
     bool deleted;
     bool is_dirty;
     bool is_wal;
+    uint32_t wal_flush_count = 0; // to keep track of the amount of flushes we performed on a WAL file
+                                  // so that we can easily recalculate real data offsets.
+                                  // On "replay" this should be refilled in order to append data
+                                  // correctly. Nevertheless, replayed wal file most probably won't be reused.
     boost::intrusive::list_member_hook<> dirty_item;
 
     std::atomic_int num_readers, num_writers;

--- a/src/os/bluestore/bluefs_types.cc
+++ b/src/os/bluestore/bluefs_types.cc
@@ -205,9 +205,9 @@ void bluefs_fnode_t::generate_test_instances(list<bluefs_fnode_t*>& ls)
 
 ostream& operator<<(ostream& out, const bluefs_fnode_t& file)
 {
-  static constexpr std::string_view node_types[] =  {
-    "LEGACY",
-    "WAL_V2",
+  static constexpr std::string_view node_type_extra_data[] =  {
+    "",
+    " type WAL_V2",
   };
 
   return out << "file(ino " << file.ino
@@ -216,7 +216,7 @@ ostream& operator<<(ostream& out, const bluefs_fnode_t& file)
 	     << " allocated " << std::hex << file.allocated << std::dec
 	     << " alloc_commit " << std::hex << file.allocated_commited << std::dec
 	     << " extents " << file.extents
-	     << " type " << node_types[file.type] << std::dec
+	     << node_type_extra_data[file.type] << std::dec
 	     << ")";
 }
 

--- a/src/os/bluestore/bluefs_types.cc
+++ b/src/os/bluestore/bluefs_types.cc
@@ -164,6 +164,10 @@ bluefs_fnode_delta_t* bluefs_fnode_t::make_delta(bluefs_fnode_delta_t* delta) {
   delta->mtime = mtime;
   delta->offset = allocated_commited;
   delta->extents.clear();
+
+  delta->type = type;
+  delta->wal_limit = wal_limit;
+  delta->wal_size = wal_size;
   if (allocated_commited < allocated) {
     uint64_t x_off = 0;
     auto p = seek(allocated_commited, &x_off);
@@ -210,14 +214,19 @@ ostream& operator<<(ostream& out, const bluefs_fnode_t& file)
     " type WAL_V2",
   };
 
-  return out << "file(ino " << file.ino
+  out << "file(ino " << file.ino
 	     << " size 0x" << std::hex << file.size << std::dec
 	     << " mtime " << file.mtime
 	     << " allocated " << std::hex << file.allocated << std::dec
 	     << " alloc_commit " << std::hex << file.allocated_commited << std::dec
-	     << " extents " << file.extents
-	     << node_type_extra_data[file.type] << std::dec
-	     << ")";
+	     << " extents " << file.extents;
+  if (file.type == WAL_V2) {
+    out << " wal_limit " << file.wal_limit << std::hex;
+    out << " wal_size " << file.wal_size << std::hex;
+    out << node_type_extra_data[file.type] << std::dec;
+  }
+  out << ")";
+  return out;
 }
 
 // bluefs_fnode_delta_t

--- a/src/os/bluestore/bluefs_types.cc
+++ b/src/os/bluestore/bluefs_types.cc
@@ -200,17 +200,23 @@ void bluefs_fnode_t::generate_test_instances(list<bluefs_fnode_t*>& ls)
   ls.back()->size = 1048576;
   ls.back()->mtime = utime_t(123,45);
   ls.back()->extents.push_back(bluefs_extent_t(0, 1048576, 4096));
-  ls.back()->__unused__ = 1;
+  ls.back()->type = 0;
 }
 
 ostream& operator<<(ostream& out, const bluefs_fnode_t& file)
 {
+  static constexpr std::string_view node_types[] =  {
+    "LEGACY",
+    "WAL_V2",
+  };
+
   return out << "file(ino " << file.ino
 	     << " size 0x" << std::hex << file.size << std::dec
 	     << " mtime " << file.mtime
 	     << " allocated " << std::hex << file.allocated << std::dec
 	     << " alloc_commit " << std::hex << file.allocated_commited << std::dec
 	     << " extents " << file.extents
+	     << " type " << node_types[file.type] << std::dec
 	     << ")";
 }
 
@@ -303,4 +309,3 @@ ostream& operator<<(ostream& out, const bluefs_transaction_t& t)
 	     << " crc 0x" << t.op_bl.crc32c(-1)
 	     << std::dec << ")";
 }
-

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -58,11 +58,17 @@ WRITE_CLASS_DENC(bluefs_fnode_delta_t)
 
 std::ostream& operator<<(std::ostream& out, const bluefs_fnode_delta_t& delta);
 
+enum bluefs_node_type {
+  LEGACY = 0,
+  WAL_V2 = 1,
+  NODE_TYPE_END = 0x100,
+};
+
 struct bluefs_fnode_t {
   uint64_t ino;
   uint64_t size;
   utime_t mtime;
-  uint8_t __unused__ = 0; // was prefer_bdev
+  uint8_t type = 0; // was prefer_bdev
   mempool::bluefs::vector<bluefs_extent_t> extents;
 
   // precalculated logical offsets for extents vector entries
@@ -115,7 +121,7 @@ struct bluefs_fnode_t {
     denc_varint(v.ino, p);
     denc_varint(v.size, p);
     denc(v.mtime, p);
-    denc(v.__unused__, p);
+    denc(v.type, p);
     denc(v.extents, p);
     DENC_FINISH(p);
   }

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -117,7 +117,13 @@ struct bluefs_fnode_t {
   template<typename T, typename P>
   friend std::enable_if_t<std::is_same_v<bluefs_fnode_t, std::remove_const_t<T>>>
   _denc_friend(T& v, P& p) {
-    DENC_START(2, 2, p);
+
+    uint8_t version = 1, compat = 1;
+    if (v.type == WAL_V2) {
+      version = 2;
+      compat = 2;
+    }
+    DENC_START(version, compat, p);
     denc_varint(v.ino, p);
     denc_varint(v.size, p);
     denc(v.mtime, p);

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -75,7 +75,7 @@ struct bluefs_fnode_delta_t {
     denc(extents, p);
 
     denc(type, p);
-    if (type == WAL_V2) {
+    if (struct_v >= 2 && type == WAL_V2) {
       ceph_assert(struct_v == 2 && struct_compat == 2);
       denc(wal_limit, p);
       denc(wal_size, p);
@@ -101,8 +101,7 @@ struct bluefs_fnode_delta_t {
     denc(v.extents, p);
 
     denc(v.type, p);
-    if (v.type == WAL_V2) {
-      ceph_assert(struct_v == 2);
+    if (struct_v >= 2 && v.type == WAL_V2) {
       denc(v.wal_limit, p);
       denc(v.wal_size, p);
     }
@@ -173,9 +172,7 @@ struct bluefs_fnode_t {
     denc(mtime, p);
     denc(type, p);
     denc(extents, p);
-    if (type == WAL_V2) {
-      ceph_assert(struct_v == 2);
-      ceph_assert(struct_compat == 2);
+    if (struct_v >= 2 && type == WAL_V2) {
       denc(wal_limit, p);
       denc(wal_size, p);
     }
@@ -198,7 +195,7 @@ struct bluefs_fnode_t {
     denc(v.mtime, p);
     denc(v.type, p);
     denc(v.extents, p);
-    if (v.type == WAL_V2) {
+    if (struct_v >= 2 && v.type == WAL_V2) {
       ceph_assert(struct_v == 2 && struct_compat == 2);
       denc(v.wal_limit, p);
       denc(v.wal_size, p);

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -117,7 +117,7 @@ struct bluefs_fnode_t {
   template<typename T, typename P>
   friend std::enable_if_t<std::is_same_v<bluefs_fnode_t, std::remove_const_t<T>>>
   _denc_friend(T& v, P& p) {
-    DENC_START(1, 1, p);
+    DENC_START(2, 2, p);
     denc_varint(v.ino, p);
     denc_varint(v.size, p);
     denc(v.mtime, p);

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -959,6 +959,59 @@ TEST(BlueFS, test_wal_write) {
   bufferlist read_bl;
   fs.read(reader, 0, 70000, &read_bl, NULL);
   ASSERT_TRUE(bl_eq(bl1, read_bl));
+  delete reader;
+
+  fs.umount();
+}
+
+TEST(BlueFS, test_wal_write_multiple) {
+  uint64_t size_wal = 1048576 * 64;
+  TempBdev bdev_wal{size_wal};
+  uint64_t size_db = 1048576 * 128;
+  TempBdev bdev_db{size_db};
+  uint64_t size_slow = 1048576 * 256;
+  TempBdev bdev_slow{size_slow};
+
+  ConfSaver conf(g_ceph_context->_conf);
+  conf.SetVal("bluefs_min_flush_size", "65536");
+  conf.ApplyChanges();
+
+  BlueFS fs(g_ceph_context);
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_WAL,  bdev_wal.path,  false));
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB,   bdev_db.path,   false));
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_SLOW, bdev_slow.path, false));
+  uuid_d fsid;
+  ASSERT_EQ(0, fs.mkfs(fsid, { BlueFS::BDEV_DB, true, true }));
+  ASSERT_EQ(0, fs.mount());
+  ASSERT_EQ(0, fs.maybe_verify_layout({ BlueFS::BDEV_DB, true, true }));
+
+  string dir_db = "db.wal";
+  ASSERT_EQ(0, fs.mkdir(dir_db));
+
+  string wal_file = "wal1.log";
+  BlueFS::FileWriter *writer;
+  ASSERT_EQ(0, fs.open_for_write(dir_db, wal_file, &writer, false));
+  ASSERT_NE(nullptr, writer);
+
+  auto gen_debugable = [](size_t amount, bufferlist& bl, char c) {
+    for (size_t i = 0; i < amount; i++) {
+      bl.append(c);
+    }
+  };
+  size_t buffer_size = 70000;
+  for (int i = 0; i < 10; i++) {
+    bufferlist bl1;
+    gen_debugable(buffer_size, bl1, 'a' + i);
+    writer->append(bl1.c_str(), bl1.length());
+    fs.fsync(writer);
+
+    BlueFS::FileReader *reader;
+    ASSERT_EQ(0, fs.open_for_read(dir_db, wal_file, &reader));
+    bufferlist read_bl;
+    fs.read(reader, i * buffer_size, buffer_size, &read_bl, NULL);
+    ASSERT_TRUE(bl_eq(bl1, read_bl));
+    delete reader;
+  }
   fs.umount();
 }
 

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -1069,6 +1069,258 @@ TEST(BlueFS, test_wal_write_multiple_recover) {
   fs.stat(dir_db, wal_file, &size, nullptr);
   ASSERT_EQ(reader->file->wal_flush_count, flush_count);
   ASSERT_EQ(size, 70000  * flush_count);
+  delete reader;
+}
+
+TEST(BlueFS, test_wal_write_multiple_recover_fsync_end) {
+  uint64_t size_wal = 1048576 * 64;
+  TempBdev bdev_wal{size_wal};
+  uint64_t size_db = 1048576 * 128;
+  TempBdev bdev_db{size_db};
+  uint64_t size_slow = 1048576 * 256;
+  TempBdev bdev_slow{size_slow};
+
+  ConfSaver conf(g_ceph_context->_conf);
+  conf.SetVal("bluefs_min_flush_size", "524288");
+  conf.ApplyChanges();
+
+  BlueFS fs(g_ceph_context);
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_WAL,  bdev_wal.path,  false));
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB,   bdev_db.path,   false));
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_SLOW, bdev_slow.path, false));
+  uuid_d fsid;
+  ASSERT_EQ(0, fs.mkfs(fsid, { BlueFS::BDEV_DB, true, true }));
+  ASSERT_EQ(0, fs.mount());
+  ASSERT_EQ(0, fs.maybe_verify_layout({ BlueFS::BDEV_DB, true, true }));
+
+  string dir_db = "db.wal";
+  ASSERT_EQ(0, fs.mkdir(dir_db));
+
+  string wal_file = "wal1.log";
+  BlueFS::FileWriter *writer;
+  ASSERT_EQ(0, fs.open_for_write(dir_db, wal_file, &writer, false));
+  ASSERT_NE(nullptr, writer);
+
+  auto gen_debugable = [](size_t amount, bufferlist& bl, char c) {
+    for (size_t i = 0; i < amount; i++) {
+      bl.append(c);
+    }
+  };
+  size_t buffer_size = 8;
+  uint64_t flush_count = 1;
+  for (int i = 0; i < 10; i++) {
+    bufferlist bl1;
+    gen_debugable(buffer_size, bl1, 'a' + i);
+    fs.append_try_flush(writer, bl1.c_str(), bl1.length());
+  }
+  fs.fsync(writer);
+  fs.close_writer(writer);
+
+  fs.umount();
+  fs.mount();
+
+  uint64_t size = 0;
+
+  { // test size
+    BlueFS::FileReader *reader;
+    ASSERT_EQ(0, fs.open_for_read(dir_db, wal_file, &reader));
+    fs.stat(dir_db, wal_file, &size, nullptr);
+    ASSERT_EQ(reader->file->wal_flush_count, flush_count);
+    ASSERT_EQ(size, buffer_size * 10);
+    delete reader;
+  }
+
+  // test contents
+  for (int i = 0; i < 10; i++) {
+    bufferlist bl1;
+    gen_debugable(buffer_size, bl1, 'a' + i);
+
+    BlueFS::FileReader *reader;
+    ASSERT_EQ(0, fs.open_for_read(dir_db, wal_file, &reader));
+    bufferlist read_bl;
+    fs.read(reader, i * buffer_size, buffer_size, &read_bl, NULL);
+    ASSERT_TRUE(bl_eq(bl1, read_bl));
+    delete reader;
+  }
+}
+
+TEST(BlueFS, test_wal_read_2_partial) {
+  uint64_t size_wal = 1048576 * 64;
+  TempBdev bdev_wal{size_wal};
+  uint64_t size_db = 1048576 * 128;
+  TempBdev bdev_db{size_db};
+  uint64_t size_slow = 1048576 * 256;
+  TempBdev bdev_slow{size_slow};
+
+  ConfSaver conf(g_ceph_context->_conf);
+  conf.SetVal("bluefs_min_flush_size", "65536");
+  conf.ApplyChanges();
+
+  BlueFS fs(g_ceph_context);
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_WAL,  bdev_wal.path,  false));
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB,   bdev_db.path,   false));
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_SLOW, bdev_slow.path, false));
+  uuid_d fsid;
+  ASSERT_EQ(0, fs.mkfs(fsid, { BlueFS::BDEV_DB, true, true }));
+  ASSERT_EQ(0, fs.mount());
+  ASSERT_EQ(0, fs.maybe_verify_layout({ BlueFS::BDEV_DB, true, true }));
+
+  string dir_db = "db.wal";
+  ASSERT_EQ(0, fs.mkdir(dir_db));
+
+
+  auto gen_debugable_alternating = [](size_t amount, bufferlist& bl, char c) {
+    for (size_t i = 0; i < amount; i++) {
+      bl.append(c + (rand() % 10));
+    }
+  };
+  uint64_t flush_count = 2;
+  uint64_t flush_size = 65536;
+  uint64_t total_size = flush_count * flush_size;
+
+  vector<uint64_t> chunk_sizes = {total_size / 32, total_size / 64};
+
+  uint64_t chunk_size = flush_size;
+  bufferlist contents;
+  ASSERT_TRUE((total_size)%chunk_size == 0);
+
+  string wal_file("wal1.log");
+
+  BlueFS::FileWriter *writer;
+  ASSERT_EQ(0, fs.open_for_write(dir_db, wal_file, &writer, false));
+  ASSERT_NE(nullptr, writer);
+  //
+  uint64_t remaining = total_size;
+  while(remaining > 0) {
+    bufferlist bl1;
+    gen_debugable_alternating(chunk_size, bl1, 'a'+ (remaining % 10));
+    fs.append_try_flush(writer, bl1.c_str(), bl1.length());
+    contents.append(bl1);
+    remaining -= chunk_size;
+  }
+  fs.fsync(writer);
+  fs.close_writer(writer);
+
+  fs.umount();
+  fs.mount();
+
+  uint64_t size = 0;
+
+
+  { // test size
+    BlueFS::FileReader *reader;
+    ASSERT_EQ(0, fs.open_for_read(dir_db, wal_file, &reader));
+    fs.stat(dir_db, wal_file, &size, nullptr);
+    ASSERT_EQ(reader->file->wal_flush_count, flush_count);
+    ASSERT_EQ(size, total_size);
+    delete reader;
+  }
+
+  BlueFS::FileReader *reader;
+  ASSERT_EQ(0, fs.open_for_read(dir_db, wal_file, &reader));
+  bufferlist read_bl;
+  uint64_t offset = chunk_size / 2; 
+  uint64_t length = chunk_size;
+  fs.read(reader, offset, length, &read_bl, NULL);
+  bufferlist chunk_contents;
+  chunk_contents.substr_of(contents, offset, length);
+  ASSERT_TRUE(bl_eq(chunk_contents, read_bl));
+  delete reader;
+
+}
+
+TEST(BlueFS, test_wal_write_multiple_recover_partial_reads) {
+  // read from the middle of one flush and end somewhere in between other flush
+  uint64_t size_wal = 1048576 * 64;
+  TempBdev bdev_wal{size_wal};
+  uint64_t size_db = 1048576 * 128;
+  TempBdev bdev_db{size_db};
+  uint64_t size_slow = 1048576 * 256;
+  TempBdev bdev_slow{size_slow};
+
+  ConfSaver conf(g_ceph_context->_conf);
+  conf.SetVal("bluefs_min_flush_size", "524288");
+  conf.ApplyChanges();
+
+  BlueFS fs(g_ceph_context);
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_WAL,  bdev_wal.path,  false));
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB,   bdev_db.path,   false));
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_SLOW, bdev_slow.path, false));
+  uuid_d fsid;
+  ASSERT_EQ(0, fs.mkfs(fsid, { BlueFS::BDEV_DB, true, true }));
+  ASSERT_EQ(0, fs.mount());
+  ASSERT_EQ(0, fs.maybe_verify_layout({ BlueFS::BDEV_DB, true, true }));
+
+  string dir_db = "db.wal";
+  ASSERT_EQ(0, fs.mkdir(dir_db));
+
+
+  auto gen_debugable_alternating = [](size_t amount, bufferlist& bl, char c) {
+    for (size_t i = 0; i < amount; i++) {
+      bl.append(c + (i % 10));
+    }
+  };
+  uint64_t flush_count = 2;
+  uint64_t flush_size = 524288;
+  uint64_t total_size = flush_count * flush_size;
+
+  vector<uint64_t> chunk_sizes = {total_size / 32, total_size / 64};
+
+  uint64_t fileid = 0;
+  for (auto chunk_size : chunk_sizes) {
+    bufferlist contents;
+    fileid++;
+    ASSERT_TRUE((total_size)%chunk_size == 0);
+
+    string wal_file("wal");
+    wal_file += to_string(fileid);
+    wal_file += ".log";
+
+    BlueFS::FileWriter *writer;
+    ASSERT_EQ(0, fs.open_for_write(dir_db, wal_file, &writer, false));
+    ASSERT_NE(nullptr, writer);
+    //
+    uint64_t remaining = total_size;
+    while(remaining > 0) {
+      bufferlist bl1;
+      gen_debugable_alternating(chunk_size, bl1, 'a'+ (remaining % 10));
+      fs.append_try_flush(writer, bl1.c_str(), bl1.length());
+      contents.append(bl1);
+      remaining -= chunk_size;
+    }
+    fs.fsync(writer);
+    fs.close_writer(writer);
+
+    fs.umount();
+    fs.mount();
+
+    uint64_t size = 0;
+
+
+    { // test size
+      BlueFS::FileReader *reader;
+      ASSERT_EQ(0, fs.open_for_read(dir_db, wal_file, &reader));
+      fs.stat(dir_db, wal_file, &size, nullptr);
+      ASSERT_EQ(reader->file->wal_flush_count, flush_count);
+      ASSERT_EQ(size, total_size);
+      delete reader;
+    }
+
+    uint64_t read_chunks =  size / chunk_size; // WAL default chunk size is 32k
+    for (int chunk = 0; chunk < read_chunks; chunk++) {
+      BlueFS::FileReader *reader;
+      ASSERT_EQ(0, fs.open_for_read(dir_db, wal_file, &reader));
+      bufferlist read_bl;
+      uint64_t offset = chunk * chunk_size; 
+      uint64_t length = chunk_size;
+      fs.read(reader, offset, length, &read_bl, NULL);
+      bufferlist chunk_contents;
+      chunk_contents.substr_of(contents, offset, length);
+      ASSERT_TRUE(bl_eq(chunk_contents, read_bl));
+      delete reader;
+    }
+
+  }
 }
 
 TEST(BlueFS, test_wal_prepend) {

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -954,14 +954,18 @@ TEST(BlueFS, test_wal_write) {
   fs.append_try_flush(writer, bl1.c_str(), bl1.length());
   fs.fsync(writer);
 
+  // WAL files don't update internal extents while writing to save memory, only on _replay
+  fs.umount();
+  fs.mount();
+
   BlueFS::FileReader *reader;
   ASSERT_EQ(0, fs.open_for_read(dir_db, wal_file, &reader));
   bufferlist read_bl;
   fs.read(reader, 0, 70000, &read_bl, NULL);
   ASSERT_TRUE(bl_eq(bl1, read_bl));
   delete reader;
-
   fs.umount();
+
 }
 
 TEST(BlueFS, test_wal_write_multiple) {
@@ -1004,6 +1008,10 @@ TEST(BlueFS, test_wal_write_multiple) {
     gen_debugable(buffer_size, bl1, 'a' + i);
     fs.append_try_flush(writer, bl1.c_str(), bl1.length());
     fs.fsync(writer);
+
+    // WAL files don't update internal extents while writing to save memory
+    fs.umount();
+    fs.mount();
 
     BlueFS::FileReader *reader;
     ASSERT_EQ(0, fs.open_for_read(dir_db, wal_file, &reader));


### PR DESCRIPTION
This is an alternative expression of signalling encoding of WAL file.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
